### PR TITLE
Fix for N-Triples serializer expanding prefixes

### DIFF
--- a/serializers/ARC2_NTriplesSerializer.php
+++ b/serializers/ARC2_NTriplesSerializer.php
@@ -30,7 +30,10 @@ class ARC2_NTriplesSerializer extends ARC2_RDFSerializer {
       if (preg_match('/^\_\:/', $v)) {
         return $v;
       }
-      if (preg_match('/^[a-z0-9]+\:[^\s\"]*$/is', $v)) {
+      if (preg_match('/^(([a-z0-9]+)\:)[^\s\"]*$/is', $v, $m)) {
+        if (!empty($m[2]) && isset($this->ns[$m[2]])) {
+          $v = preg_replace('/^' . preg_quote($m[1]) . '/', $this->ns[$m[2]], $v);
+        }
         return '<' . $this->escape($v) . '>';
       }
       return $this->getTerm(array('type' => 'literal', 'value' => $v));


### PR DESCRIPTION
The N-Triples serializer did not expand namespace prefixes into the full URI values, as it should in [N-Triples grammar](http://www.w3.org/2001/sw/RDFCore/ntriples/#sec-grammar). The requested commit adds this feature by matching prefixes against known namespace prefixes (in `$this->ns`) and replacing the prefix followed by a colon with the full namespace base.
