### PR TITLE
Bug fix for bug stated here: http://groups.google.com/group/arc-dev/browse_thread/thread/410becee0f1aa205/53cb84bab6a0b283#53cb84bab6a0b283

### DIFF
--- a/store/ARC2_StoreSelectQueryHandler.php
+++ b/store/ARC2_StoreSelectQueryHandler.php
@@ -616,8 +616,8 @@ class ARC2_StoreSelectQueryHandler extends ARC2_StoreQueryHandler {
     foreach ($id2code as $id => $code) {
       $deps[$id]['rank'] = 0;
       foreach ($id2code as $other_id => $other_code) {
-        $deps[$id]['rank'] += ($id != $other_id) && preg_match('/' . $other_id . '/', $code) ? 1 : 0;
-        $deps[$id][$other_id] = ($id != $other_id) && preg_match('/' . $other_id . '/', $code) ? 1 : 0;
+        $deps[$id]['rank'] += ($id != $other_id) && preg_match('/' . $other_id . '\\D/', $code) ? 1 : 0;
+        $deps[$id][$other_id] = ($id != $other_id) && preg_match('/' . $other_id . '\\D/', $code) ? 1 : 0;
       }
     }
     $r = '';


### PR DESCRIPTION
Hi,

this contains a bugfix for a wrong regular expression.
Upon doing some more research we found the source of the problem.

Line 619 and 620 of ARC2_StoreSelectQueryHandler:
        $deps[$id]['rank'] += ($id != $other_id) && preg_match('/' .
$other_id . '/', $code) ? 1 : 0;
        $deps[$id][$other_id] = ($id != $other_id) && preg_match('/' .
$other_id . '/', $code) ? 1 : 0;
The preg_match must be:
        $deps[$id]['rank'] += ($id != $other_id) && preg_match('/' .
$other_id . '\D/', $code) ? 1 : 0;
        $deps[$id][$other_id] = ($id != $other_id) && preg_match('/' .
$other_id . '\D/', $code) ? 1 : 0;
because otherwise T_0_0_1 matches T_0_0_10 or T_0_0_13 although there
is no connection between them. 

Therefore arc2 always told us it could not resolve all dependencies as T_0_0_1 was always found if any T above 9 was in the dependencies.

Sincerely,

Mark
