### PR TITLE
Correcting encoding for DB connection upon DB creation

### DIFF
--- a/store/ARC2_Store.php
+++ b/store/ARC2_Store.php
@@ -63,6 +63,7 @@ class ARC2_Store extends ARC2_Class {
           ", $db_con, 1
         );
         if (mysql_select_db($this->a['db_name'], $db_con)) {
+          $this->queryDB("SET NAMES 'utf8'", $db_con);
           $fixed = 1;
         }
       }


### PR DESCRIPTION
Explicitly setting UTF encoding if creating a new database, since getCollation does not properly detect it right after creation.

See [SO](http://stackoverflow.com/questions/9331239) for symptoms details.
