### PR TITLE
Add a setRel() in addition to setProp() for URIs instead of litterals.

### DIFF
--- a/ARC2_Resource.php
+++ b/ARC2_Resource.php
@@ -57,6 +57,14 @@ class ARC2_Resource extends ARC2_Class {
     $this->index[$s][$this->expandPName($p)] = $os;
   }
 
+  /* add a relation to a URI. Allows for instance $res->setRel('rdf:type', 'doap:Project') */
+  function setRel($p, $r, $s = '') {
+    $uri = array (
+		  'type' => 'uri',
+		  'value' => $this->expandPName($r));
+    $this->setProp($p, $uri, $s);
+  }
+  
   function setStore($store) {
     $this->store = $store;
   }


### PR DESCRIPTION
This allows adding a "relation" to a URI instead of only being able to set litteral properties.

Allows $res->setRel('rdf:type', 'doap:Project') for instance.

Hope this helps,
