### PR TITLE
Allow to easily set xsd:dateTime on Resources

### DIFF
--- a/ARC2_Resource.php
+++ b/ARC2_Resource.php
@@ -78,6 +78,14 @@ class ARC2_Resource extends ARC2_Class {
     }
   }
 
+  /* Specialize setProp to set an xsd:dateTime typed literal. Example : $res->setPropXSDdateTime('dcterms:created', date('c')) */
+  function setPropXSDdateTime($p, $dt, $s = '') {
+	$datecreated=array('value' => $dt,
+		'type' => 'literal',
+		'datatype' => 'http://www.w3.org/2001/XMLSchema#dateTime');
+	$this->setProp($p, $datecreated, $s);
+  }
+
   function setStore($store) {
     $this->store = $store;
   }


### PR DESCRIPTION
The Resources support the setting, with setProp, of typed litterals, although it is far from obvious, and undocumented AFAIK.

Here's my suggestion to add a specialized setProp variant for xsd:dateTime.

It may be improved to support passing multiple values, etc.

Feel free to improve.
