### PR TITLE
 	Fix for HTTPS requests + Added text/turtle to Accept Header.

### DIFF
--- a/ARC2_Reader.php
+++ b/ARC2_Reader.php
@@ -21,7 +21,7 @@ class ARC2_Reader extends ARC2_Class {
     parent::__init();
     $this->http_method = $this->v('http_method', 'GET', $this->a);
     $this->message_body = $this->v('message_body', '', $this->a);;
-    $this->http_accept_header = $this->v('http_accept_header', 'Accept: application/rdf+xml; q=0.9, */*; q=0.1', $this->a);
+    $this->http_accept_header = $this->v('http_accept_header', 'Accept: application/rdf+xml; q=0.9, text/turtle; q=0.8, */*; q=0.1', $this->a);
     $this->http_user_agent_header = $this->v('http_user_agent_header', 'User-Agent: ARC Reader (http://arc.semsol.org/)', $this->a);
     $this->http_custom_headers = $this->v('http_custom_headers', '', $this->a);
     $this->max_redirects = $this->v('max_redirects', 3, $this->a);


### PR DESCRIPTION
This was confusing some webservers, specifically the one at data.ox.ac.uk. 

The previous code showed the port number on https unless the port number was '80'. I've altered it to not include 443 in host requests when using https.

The following test should show the fix in action:

<pre>
require_once( "arc/ARC2.php" );

$uri = "https://data.ox.ac.uk/doc/vacancy/105043.rdf";
$parser = ARC2::getRDFXMLParser();
$parser->parse( $uri );

$errors = $parser->getErrors();
if( sizeof($errors) )
{
        print join( ",",$errors)."\n";
}
else
{
        print "loaded ".sizeof( $parser->getTriples() )." triples.\n";
}
</pre>

---

Also, some sites, notably facebook now offer text/turtle but not application/rdf+xml my second alteration makes ARC2 play nice with facebook RDF. Test case here:

<pre>
require_once( "arc/ARC2.php" );
$uri = "http://graph.facebook.com/601351881?metadata=1";
$parser = ARC2::getRDFParser();
$parser->parse( $uri );

$errors = $parser->getErrors();
if( sizeof($errors) )
{
        print join( ", ",$errors)."\n";
}
else
{
    print "loaded ".sizeof( $parser->getTriples() )." triples\n";
}
</pre>

