### PR TITLE
preg_replace with /e modifier is deprecated: use preg_replace_callback instead

### DIFF
--- a/ARC2_Class.php
+++ b/ARC2_Class.php
@@ -75,7 +75,9 @@ class ARC2_Class {
 
   function deCamelCase($v, $uc_first = 0) {
     $r = str_replace('_', ' ', $v);
-    $r = preg_replace('/([a-z0-9])([A-Z])/e', '"\\1 " . strtolower("\\2")', $r);
+    $r = preg_replace_callback('/([a-z0-9])([A-Z])/', function($matches) {
+      return $matches[1] . ' ' . strtolower($matches[2]);
+    }, $r);
     return $uc_first ? ucfirst($r) : $r;
   }
 

--- a/parsers/ARC2_JSONParser.php
+++ b/parsers/ARC2_JSONParser.php
@@ -116,8 +116,10 @@ class ARC2_JSONParser extends ARC2_RDFParser {
       if (preg_match('/^([^\x5c]*|.*[^\x5c]|.*\x5c{2})\"(.*)$/sU', $rest, $m)) {
         $val = $m[1];
         /* unescape chars (single-byte) */
-        $val = preg_replace('/\\\u(.{4})/e', 'chr(hexdec("\\1"))', $val);
-        //$val = preg_replace('/\\\u00(.{2})/e', 'rawurldecode("%\\1")', $val);
+        $val = preg_replace_callback('/\\\u(.{4})/', function($matches) {
+          return chr(hexdec($matches[1]));
+        }, $val);
+        //$val = preg_replace_callback('/\\\u00(.{2})', function($matches) { return rawurldecode("%" . $matches[1]); }, $val);
         /* other escaped chars */
         $from = array('\\\\', '\r', '\t', '\n', '\"', '\b', '\f', '\/');
         $to = array("\\", "\r", "\t", "\n", '"', "\b", "\f", "/");

--- a/serializers/ARC2_NTriplesSerializer.php
+++ b/serializers/ARC2_NTriplesSerializer.php
@@ -131,8 +131,12 @@ class ARC2_NTriplesSerializer extends ARC2_RDFSerializer {
 		if (substr($r, 0, 1) == '"') $r = substr($r, 1);
 		if (substr($r, -1) == '"') $r = substr($r, 0, -1);
 		// uppercase hex chars
-		$r = preg_replace('/(\\\u)([0-9a-f]{4})/e', "'\\1' . strtoupper('\\2')", $r);
-		$r = preg_replace('/(\\\U)([0-9a-f]{8})/e', "'\\1' . strtoupper('\\2')", $r);
+		$r = preg_replace_callback('/(\\\u)([0-9a-f]{4})', function($matches) {
+      return $matches[1] . strtoupper($matches[2]);
+    }, $r);
+		$r = preg_replace_callback('/(\\\U)([0-9a-f]{8})', function($matches) {
+      return $matches[1] . strtoupper($matches[2]);
+    }, $r);
 	}
 	// escape byte-wise (may be wrong for mb chars and newer php versions)
 	else {

--- a/store/ARC2_MemStore.php
+++ b/store/ARC2_MemStore.php
@@ -185,7 +185,9 @@ class ARC2_MemStore extends ARC2_Class {
     else {
       $r = preg_replace("/^(.*[\/\#])([^\/\#]+)$/", '\\2', str_replace('#self', '', $res));
       $r = str_replace('_', ' ', $r);
-      $r = preg_replace('/([a-z])([A-Z])/e', '"\\1 " . strtolower("\\2")', $r);
+      $r = preg_replace_callback('/([a-z])([A-Z])/', function($matches) {
+        return $matches[1] . ' ' . strtolower($matches[2]);
+      }, $r);
     }
     $this->resource_labels[$res] = $r;
     return $r;

--- a/store/ARC2_RemoteStore.php
+++ b/store/ARC2_RemoteStore.php
@@ -185,7 +185,9 @@ class ARC2_RemoteStore extends ARC2_Class {
     else {
       $r = preg_replace("/^(.*[\/\#])([^\/\#]+)$/", '\\2', str_replace('#self', '', $res));
       $r = str_replace('_', ' ', $r);
-      $r = preg_replace('/([a-z])([A-Z])/e', '"\\1 " . strtolower("\\2")', $r);
+      $r = preg_replace_callback('/([a-z])([A-Z])/', function($matches) {
+        return $matches[1] . ' ' . strtolower($matches[2]);
+      }, $r);
     }
     $this->resource_labels[$res] = $r;
     return $r;

--- a/store/ARC2_Store.php
+++ b/store/ARC2_Store.php
@@ -655,7 +655,9 @@ class ARC2_Store extends ARC2_Class {
     }
     $r = $r ? $r : preg_replace("/^(.*[\/\#])([^\/\#]+)$/", '\\2', str_replace('#self', '', $res));
     $r = str_replace('_', ' ', $r);
-    $r = preg_replace('/([a-z])([A-Z])/e', '"\\1 " . strtolower("\\2")', $r);
+    $r = preg_replace_callback('/([a-z])([A-Z])/', function($matches) {
+      return $matches[1] . ' ' . strtolower($matches[2]);
+    }, $r);
     $this->resource_labels[$res] = $r;
     return $r;
   }


### PR DESCRIPTION
The /e modifier is deprecated as of PHP 5.5.0
