### PR TITLE
Convert mysql_ to mysqli_

### DIFF
--- a/ARC2_Class.php
+++ b/ARC2_Class.php
@@ -484,7 +484,7 @@ class ARC2_Class {
 
   function queryDB($sql, $con, $log_errors = 0) {
     $t1 = ARC2::mtime();
-    $r = mysql_query($sql, $con);
+    $r = mysqli_query( $con, $sql);
     if (0) {
       $t2 = ARC2::mtime() - $t1;
       $call_obj = $this;
@@ -495,7 +495,8 @@ class ARC2_Class {
       }
       echo "\n" . $call_path . " needed " . $t2 . ' secs for ' . str_replace("\n" , ' ', $sql);;
     }
-    if ($log_errors && ($er = mysql_error($con))) $this->addError($er);
+    $er = mysqli_error($con);
+    if ($log_errors && !empty($er)) $this->addError($er);
     return $r;
   }
 

--- a/store/ARC2_StoreAskQueryHandler.php
+++ b/store/ARC2_StoreAskQueryHandler.php
@@ -41,8 +41,8 @@ class ARC2_StoreAskQueryHandler extends ARC2_StoreSelectQueryHandler {
   
   function getFinalQueryResult($q_sql, $tmp_tbl) {
     $con = $this->store->getDBCon();
-    $rs = mysql_query('SELECT success FROM ' . $tmp_tbl, $con);
-    $r = ($row = mysql_fetch_array($rs)) ? $row['success'] : 0;
+    $rs = mysqli_query( $con, 'SELECT success FROM ' . $tmp_tbl);
+    $r = ($row = mysqli_fetch_array($rs)) ? $row['success'] : 0;
     return $r ? true : false;
   }
 

--- a/store/ARC2_StoreDeleteQueryHandler.php
+++ b/store/ARC2_StoreDeleteQueryHandler.php
@@ -65,8 +65,8 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
     $con = $this->store->getDBCon();
     foreach ($this->infos['query']['target_graphs'] as $g) {
       if ($g_id = $this->getTermID($g, 'g')) {
-        $rs = mysql_query('DELETE FROM ' . $tbl_prefix . 'g2t WHERE g = ' .$g_id, $con);
-        $r += mysql_affected_rows($con);
+        $rs = mysqli_query( $con, 'DELETE FROM ' . $tbl_prefix . 'g2t WHERE g = ' .$g_id);
+        $r += mysqli_affected_rows($con);
       }
     }
     $this->refs_deleted = $r ? 1 : 0;
@@ -128,10 +128,11 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
       }
       //$rs = mysql_query($sql, $con);
       $rs = $this->queryDB($sql, $con);
-      if ($er = mysql_error($con)) {
+      $er = mysqli_error($con);
+      if (!empty($er)) {
         $this->addError($er .' in ' . $sql);
       }
-      $r += mysql_affected_rows($con);
+      $r += mysqli_affected_rows($con);
     }
     return $r;
   }
@@ -161,7 +162,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
       SELECT T.t FROM '. $tbl_prefix . 'triple T LEFT JOIN '. $tbl_prefix . 'g2t G ON ( G.t = T.t )
       WHERE G.t IS NULL LIMIT 1
     ';
-    if (($rs = mysql_query($sql, $con)) && mysql_num_rows($rs)) {
+    if (($rs = mysqli_query( $con, $sql)) && mysqli_num_rows($rs)) {
       /* delete unconnected triples */
       $sql = ($dbv < '04-01') ? 'DELETE ' . $tbl_prefix . 'triple' : 'DELETE T';
       $sql .= '
@@ -169,7 +170,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
         LEFT JOIN ' . $tbl_prefix . 'g2t G ON (G.t = T.t)
         WHERE G.t IS NULL
       ';
-      mysql_query($sql, $con);
+      mysqli_query( $con, $sql);
     }
     /* check for unconnected graph refs */
     if ((rand(1, 10) == 1)) {
@@ -177,7 +178,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
         SELECT G.g FROM '. $tbl_prefix . 'g2t G LEFT JOIN '. $tbl_prefix . 'triple T ON ( T.t = G.t )
         WHERE T.t IS NULL LIMIT 1
       ';
-      if (($rs = mysql_query($sql, $con)) && mysql_num_rows($rs)) {
+      if (($rs = mysqli_query( $con, $sql)) && mysqli_num_rows($rs)) {
         /* delete unconnected graph refs */
         $sql = ($dbv < '04-01') ? 'DELETE ' . $tbl_prefix . 'g2t' : 'DELETE G';
         $sql .= '
@@ -185,7 +186,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
           LEFT JOIN ' . $tbl_prefix . 'triple T ON (T.t = G.t)
           WHERE T.t IS NULL
         ';
-        mysql_query($sql, $con);
+        mysqli_query( $con, $sql);
       }
     }
     /* release lock */
@@ -207,7 +208,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
       LEFT JOIN ' . $tbl_prefix . 'triple T ON (T.o = V.id)
       WHERE T.t IS NULL
     ';
-    mysql_query($sql, $con);
+    mysqli_query( $con, $sql);
     /* s2val */
     $sql = ($dbv < '04-01') ? 'DELETE ' . $tbl_prefix . 's2val' : 'DELETE V';
     $sql .= '
@@ -215,7 +216,7 @@ class ARC2_StoreDeleteQueryHandler extends ARC2_StoreQueryHandler {
       LEFT JOIN ' . $tbl_prefix . 'triple T ON (T.s = V.id)
       WHERE T.t IS NULL
     ';
-    mysql_query($sql, $con);
+    mysqli_query( $con, $sql);
     /* id2val */
     $sql = ($dbv < '04-01') ? 'DELETE ' . $tbl_prefix . 'id2val' : 'DELETE V';
     $sql .= '

--- a/store/ARC2_StoreDumper.php
+++ b/store/ARC2_StoreDumper.php
@@ -45,7 +45,7 @@ class ARC2_StoreDumper extends ARC2_Class {
       $proceed = 0;
       $rs = $this->getRecordset($offset);
       if (!$rs) break;
-      while ($row = mysql_fetch_array($rs)) {
+      while ($row = mysqli_fetch_array($rs)) {
         echo $this->getEntry($row);
         $proceed = 1;
       }
@@ -65,7 +65,7 @@ class ARC2_StoreDumper extends ARC2_Class {
       $proceed = 0;
       $rs = $this->getRecordset($offset);
       if (!$rs) break;
-      while ($row = mysql_fetch_array($rs)) {
+      while ($row = mysqli_fetch_array($rs)) {
         fwrite($fp, $this->getEntry($row));
         $proceed = 1;
       }
@@ -116,8 +116,9 @@ class ARC2_StoreDumper extends ARC2_Class {
     ';
     if ($this->limit) $sql .= ' LIMIT ' . $this->limit;
     if ($offset) $sql .= ' OFFSET ' . $offset;
-    $rs = mysql_unbuffered_query($sql, $con);
-    if (($err = mysql_error($con))) {
+    $rs = mysqli_query( $con, $sql, MYSQLI_USE_RESULT);
+    $err = mysqli_error($con);
+    if (!empty($err)) {
       return $this->addError($err);
     }
     return $rs;

--- a/store/ARC2_StoreEndpoint.php
+++ b/store/ARC2_StoreEndpoint.php
@@ -425,15 +425,15 @@ class ARC2_StoreEndpoint extends ARC2_Store {
           $r .= '        "' .$var. '": {';
           if ($row[$var . ' type'] == 'uri') {
             $r .= $nl . '          "type": "uri",';
-            $r .= $nl . '          "value": "' .mysql_real_escape_string($row[$var], $con). '"';
+            $r .= $nl . '          "value": "' .mysqli_real_escape_string( $con, $row[$var]). '"';
           }
           elseif ($row[$var . ' type'] == 'bnode') {
             $r .= $nl . '          "type": "bnode",';
             $r .= $nl . '          "value": "' . substr($row[$var], 2) . '"';
           }
           else {
-            $dt = isset($row[$var . ' datatype']) ? ',' . $nl .'          "datatype": "' .mysql_real_escape_string($row[$var . ' datatype'], $con). '"' : '';
-            $lang = isset($row[$var . ' lang']) ? ',' . $nl .'          "xml:lang": "' .mysql_real_escape_string($row[$var . ' lang'], $con). '"' : '';
+            $dt = isset($row[$var . ' datatype']) ? ',' . $nl .'          "datatype": "' .mysqli_real_escape_string( $con, $row[$var . ' datatype']). '"' : '';
+            $lang = isset($row[$var . ' lang']) ? ',' . $nl .'          "xml:lang": "' .mysqli_real_escape_string( $con, $row[$var . ' lang']). '"' : '';
             $type = $dt ? 'typed-literal' : 'literal';
             $r .= $nl . '          "type": "' . $type . '",';
             $r .= $nl . '          "value": "' . $this->jsonEscape($row[$var]) . '"';

--- a/store/ARC2_StoreHelper.php
+++ b/store/ARC2_StoreHelper.php
@@ -31,15 +31,15 @@ class ARC2_StoreHelper extends ARC2_Class {
       $con = $this->store->getDBCon();
       foreach (array('id', 's', 'o') as $id_col) {
         $tbl = $this->store->getTablePrefix() . $id_col . '2val';
-        $sql = 'SELECT id, val FROM ' . $tbl . ' WHERE val LIKE "' . mysql_real_escape_string($old_uri, $con). '%"';
-        $rs = mysql_query($sql, $con);
+        $sql = 'SELECT id, val FROM ' . $tbl . ' WHERE val LIKE "' . mysqli_real_escape_string( $con, $old_uri). '%"';
+        $rs = mysqli_query( $con, $sql);
         if (!$rs) continue;
-        while ($row = mysql_fetch_array($rs)) {
+        while ($row = mysqli_fetch_array($rs)) {
           $new_val = str_replace($old_uri, $new_uri, $row['val']);
           $new_id = $this->store->getTermID($new_val, $id_col);
           if (!$new_id) {/* unknown ns uri, overwrite current id value */
-            $sub_sql = "UPDATE " . $tbl . " SET val = '" . mysql_real_escape_string($new_val, $con) . "' WHERE id = " . $row['id'];
-            $sub_r = mysql_query($sub_sql, $con);
+            $sub_sql = "UPDATE " . $tbl . " SET val = '" . mysqli_real_escape_string( $con, $new_val) . "' WHERE id = " . $row['id'];
+            $sub_r = mysqli_query( $con, $sub_sql);
             $id_changes++;
           }
           else {/* replace ids */
@@ -48,8 +48,8 @@ class ARC2_StoreHelper extends ARC2_Class {
               if (preg_match('/^triple/', $t_tbl)) {
                 foreach (array('s', 'p', 'o', 'o_lang_dt') as $t_col) {
                   $sub_sql = "UPDATE " . $this->store->getTablePrefix() . $t_tbl . " SET " . $t_col . " = " . $new_id . " WHERE " . $t_col . " = " . $row['id'];
-                  $sub_r = mysql_query($sub_sql, $con);
-                  $t_changes += mysql_affected_rows($con);
+                  $sub_r = mysqli_query( $con, $sub_sql);
+                  $t_changes += mysqli_affected_rows($con);
                 }
               }
             }

--- a/store/ARC2_StoreTableManager.php
+++ b/store/ARC2_StoreTableManager.php
@@ -39,22 +39,22 @@ class ARC2_StoreTableManager extends ARC2_Store {
   function createTables() {
     $con = $this->getDBCon();
     if(!$this->createTripleTable()) {
-      return $this->addError('Could not create "triple" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "triple" table (' . mysqli_error($con) . ').');
     }
     if(!$this->createG2TTable()) {
-      return $this->addError('Could not create "g2t" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "g2t" table (' . mysqli_error($con) . ').');
     }
     if(!$this->createID2ValTable()) {
-      return $this->addError('Could not create "id2val" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "id2val" table (' . mysqli_error($con) . ').');
     }
     if(!$this->createS2ValTable()) {
-      return $this->addError('Could not create "s2val" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "s2val" table (' . mysqli_error($con) . ').');
     }
     if(!$this->createO2ValTable()) {
-      return $this->addError('Could not create "o2val" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "o2val" table (' . mysqli_error($con) . ').');
     }
     if(!$this->createSettingTable()) {
-      return $this->addError('Could not create "setting" table (' . mysql_error($con) . ').');
+      return $this->addError('Could not create "setting" table (' . mysqli_error($con) . ').');
     }
     return 1;
   }
@@ -79,7 +79,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         UNIQUE KEY (t), " . $index_code . " KEY (misc)
       ) ". $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
 
   function extendTripleTableColumns($suffix = 'triple') {
@@ -91,7 +91,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
       MODIFY o int(10) UNSIGNED NOT NULL,
       MODIFY o_lang_dt int(10) UNSIGNED NOT NULL
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
   
   /*  */
@@ -104,7 +104,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         UNIQUE KEY gt (g,t), KEY tg (t,g)
       ) ". $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }  
   
   function extendG2tTableColumns($suffix = 'g2t') {
@@ -113,7 +113,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
       MODIFY g int(10) UNSIGNED NOT NULL,
       MODIFY t int(10) UNSIGNED NOT NULL
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
 
   /*  */
@@ -128,7 +128,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         UNIQUE KEY (id,val_type), KEY v (val(64))
       ) ". $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }  
   
   function extendId2valTableColumns($suffix = 'id2val') {
@@ -136,7 +136,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
       ALTER TABLE " . $this->getTablePrefix() . $suffix . "
       MODIFY id int(10) UNSIGNED NOT NULL
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
 
   /*  */
@@ -153,7 +153,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         " . $indexes . "
       ) " . $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }  
   
   function extendS2valTableColumns($suffix = 's2val') {
@@ -161,7 +161,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
       ALTER TABLE " . $this->getTablePrefix() . $suffix . "
       MODIFY id int(10) UNSIGNED NOT NULL
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
 
   /*  */
@@ -179,7 +179,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         UNIQUE KEY (id), KEY vh (val_hash)" . $val_index . "
       ) ". $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }  
   
   function extendO2valTableColumns($suffix = 'o2val') {
@@ -187,7 +187,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
       ALTER TABLE " . $this->getTablePrefix() . $suffix . "
       MODIFY id int(10) UNSIGNED NOT NULL
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }
 
   /*  */
@@ -200,7 +200,7 @@ class ARC2_StoreTableManager extends ARC2_Store {
         UNIQUE KEY (k)
       ) ". $this->getTableOptionsCode() . "
     ";
-    return mysql_query($sql, $this->getDBCon());
+    return mysqli_query( $this->getDBCon(), $sql);
   }  
   
   /*  */
@@ -244,8 +244,8 @@ class ARC2_StoreTableManager extends ARC2_Store {
       INSERT IGNORE INTO ' . $new_tbl .'
       SELECT * FROM ' . $old_tbl . ' WHERE ' . $old_tbl . '.p = ' . $p_id . '
     ';
-    if ($rs = mysql_query($sql, $con)) {
-      mysql_query('DROP TABLE ' . $old_tbl, $con);
+    if ($rs = mysqli_query( $con, $sql)) {
+      mysqli_query( $con, 'DROP TABLE ' . $old_tbl);
       return 1;
     }
     else {
@@ -264,12 +264,12 @@ class ARC2_StoreTableManager extends ARC2_Store {
       INSERT IGNORE INTO ' . $new_tbl .'
       SELECT * FROM ' . $old_tbl . ' WHERE ' . $old_tbl . '.p = ' . $p_id . '
     ';
-    if ($rs = mysql_query($sql, $con)) {
-      mysql_query('DELETE FROM ' . $old_tbl . ' WHERE ' . $old_tbl . '.p = ' . $p_id, $con);
+    if ($rs = mysqli_query( $con, $sql)) {
+      mysqli_query( $con, 'DELETE FROM ' . $old_tbl . ' WHERE ' . $old_tbl . '.p = ' . $p_id);
       return 1;
     }
     else {
-      mysql_query('DROP TABLE ' . $new_tbl, $con);
+      mysqli_query( $con, 'DROP TABLE ' . $new_tbl);
       return 0;
     }
   }


### PR DESCRIPTION
Change mysql_ methods to mysqli_, removing deprecation warnings from the former.  Used https://github.com/philip/MySQLConverterTool with additional cleanup.
