### PR TITLE
Make id column in table id2val a PRIMARY KEY and set AUTO_INCREMENT

### DIFF
--- a/store/ARC2_StoreTableManager.php
+++ b/store/ARC2_StoreTableManager.php
@@ -121,11 +121,13 @@ class ARC2_StoreTableManager extends ARC2_Store {
   function createID2ValTable() {
     $sql = "
       CREATE TABLE IF NOT EXISTS " . $this->getTablePrefix() . "id2val (
-        id mediumint UNSIGNED NOT NULL,
+        id mediumint UNSIGNED NOT NULL AUTO_INCREMENT,
         misc tinyint(1) NOT NULL default 0,
         val text NOT NULL,
         val_type tinyint(1) NOT NULL default 0,     /* uri/bnode/literal => 0/1/2 */
-        UNIQUE KEY (id,val_type), KEY v (val(64))
+        PRIMARY KEY (`id`), 
+        UNIQUE KEY (id,val_type), 
+        KEY v (val(64))
       ) ". $this->getTableOptionsCode() . "
     ";
     return mysqli_query( $this->getDBCon(), $sql);


### PR DESCRIPTION
The reason for that change is to improve the handling of that table, if you need to manage it manually.

Without that change, if you want to add a new entry to that table, you have to first count of all entries of the table, increment that number and use it as the new value of the id-column. But using that method can let you run into [race conditions](http://en.wikipedia.org/wiki/Race_condition), highly problematic in situation with a high number of write and read operations.

With my change, you let MySQL increase the value of the id-column. Which means, you only pass the values for the other columns and MySQL auto increment the value. Using Primary Key for id-column let it become a real "id".

Of course, existing tables have to be upgraded. You can do that by executing the following SQL-queries in the according MySQL-table (replace XXX with your chosen prefix):

```
ALTER TABLE `XXX_id2val` ADD PRIMARY KEY(`id`)
ALTER TABLE  `XXX_id2val` CHANGE  `id`  `id` MEDIUMINT( 8 ) UNSIGNED NOT NULL AUTO_INCREMENT
```