### PR TITLE
extended composer PSR4 for tests; added simple Store setup-test to check fix for #94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ triggers/*
 tests/coverage/*
 /composer.lock
 vendor/
+tests/config.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ cache:
 sudo: true
 
 before_install:
+    - mysql -e 'CREATE DATABASE IF NOT EXISTS testdb;'
     - composer require satooshi/php-coveralls:* --ignore-platform-reqs
     - travis_retry composer install --dev --no-interaction --ignore-platform-reqs
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,23 @@
     "require-dev": {
         "phpunit/phpunit": "^5.0"
     },
-     "autoload": {
-        "classmap": ["./","parsers/","serializers/"]
+    "autoload": {
+        "classmap": ["parsers/", "serializers/"],
+        "files": [
+            "./ARC2.php",
+            "./ARC2_Class.php",
+            "./ARC2_getFormat.php",
+            "./ARC2_getPreferredFormat.php",
+            "./ARC2_Graph.php",
+            "./ARC2_Reader.php",
+            "./ARC2_Resource.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": [
+                "tests"
+            ]
+        }
     }
 }

--- a/store/ARC2_Store.php
+++ b/store/ARC2_Store.php
@@ -52,17 +52,17 @@ class ARC2_Store extends ARC2_Class {
       return $this->addError(mysqli_error($db_con));
     }
     $this->a['db_con'] = $db_con;
-    if (!mysqli_query( $db_con, "USE " . $this->a['db_name'])) {
+    if (!mysqli_query( $db_con, "USE `" . $this->a['db_name'] .'`')) {
       $fixed = 0;
       /* try to create it */
       if ($this->a['db_name']) {
         $this->queryDB("
-          CREATE DATABASE IF NOT EXISTS " . $this->a['db_name'] . " 
+          CREATE DATABASE IF NOT EXISTS `" . $this->a['db_name'] . "`
           DEFAULT CHARACTER SET utf8
           DEFAULT COLLATE utf8_general_ci
           ", $db_con, 1
         );
-        if (mysqli_query( $db_con, "USE " . $this->a['db_name'])) {
+        if (mysqli_query( $db_con, "USE `" . $this->a['db_name'] .'`')) {
           $this->queryDB("SET NAMES 'utf8'", $db_con);
           $fixed = 1;
         }

--- a/tests/ARC2_TestCase.php
+++ b/tests/ARC2_TestCase.php
@@ -1,5 +1,15 @@
 <?php
 
-class ARC2_TestCase extends PHPUnit\Framework\TestCase
+namespace Tests;
+
+class ARC2_TestCase extends \PHPUnit\Framework\TestCase
 {
+    protected $dbConfig;
+
+    public function setUp()
+    {
+        global $dbConfig;
+
+        $this->dbConfig = $dbConfig;
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,5 +2,20 @@
 
 require_once __DIR__ .'/../vendor/autoload.php';
 
-require 'ARC2_TestCase.php';
 require 'ARC2_TestHandler.php';
+
+global $dbConfig;
+
+if (file_exists(__DIR__ .'/config.php')) {
+    // use custom DB credentials, if available
+    $dbConfig = require 'config.php';
+
+} else {
+    // standard DB credentials (ready to use in Travis)
+    $dbConfig = array(
+        'db_name' => 'testdb',
+        'db_user' => 'root',
+        'db_pwd'  => '',
+        'db_host' => 'localhost',
+    );
+}

--- a/tests/config.php.dist
+++ b/tests/config.php.dist
@@ -1,0 +1,12 @@
+<?php
+
+/*
+ * adapt this file, if you want to define custom database credentials.
+ */
+
+return array(
+    'db_name' => 'testdb',
+    'db_user' => 'root',
+    'db_pwd'  => 'Pass123',
+    'db_host' => 'localhost',
+);

--- a/tests/integration/store/ARC2_StoreTest.php
+++ b/tests/integration/store/ARC2_StoreTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\integration;
+
+use Tests\ARC2_TestCase;
+
+class ARC2_StoreTest extends ARC2_TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->fixture = \ARC2::getStore($this->dbConfig);
+    }
+
+    public function testSetup()
+    {
+        $this->fixture->reset();
+
+        $this->fixture->setup();
+    }
+}

--- a/tests/unit/ARC2_GraphTest.php
+++ b/tests/unit/ARC2_GraphTest.php
@@ -1,12 +1,16 @@
 <?php
 
+namespace Tests\unit;
+
+use Tests\ARC2_TestCase;
+
 class ARC2_GraphTest extends ARC2_TestCase {
 
 	public function setUp()
 	{
 		parent::setUp();
 
-		$this->obj = ARC2::getGraph();
+		$this->obj = \ARC2::getGraph();
 		$this->res1 = array(
 			'http://example.com/s1' => array(
 				'http://example.com/p1' => array(
@@ -68,7 +72,7 @@ class ARC2_GraphTest extends ARC2_TestCase {
 
 	public function testAddGraph() {
 		$this->obj->addIndex($this->res1);
-		$g2 = ARC2::getGraph()->addIndex($this->res2);
+		$g2 = \ARC2::getGraph()->addIndex($this->res2);
 
 		$actual = $this->obj->addGraph($g2);
 		$this->assertSame($this->obj, $actual);
@@ -78,7 +82,7 @@ class ARC2_GraphTest extends ARC2_TestCase {
 	}
 
 	public function testAddGraphWithNamespaces() {
-		$g2 = ARC2::getGraph()->setPrefix('ex', 'http://example.com/');
+		$g2 = \ARC2::getGraph()->setPrefix('ex', 'http://example.com/');
 
 		$actual = $this->obj->addGraph($g2);
 		$this->assertArrayHasKey('ex', $actual->ns);

--- a/tests/unit/ARC2_Test.php
+++ b/tests/unit/ARC2_Test.php
@@ -1,122 +1,126 @@
 <?php
 
+namespace Tests\unit;
+
+use Tests\ARC2_TestCase;
+
 class ARC2_Test extends ARC2_TestCase {
 
 	public function testGetVersion() {
-		$actual = ARC2::getVersion();
+		$actual = \ARC2::getVersion();
 		$this->assertRegExp('/^[0-9]{4}-[0-9]{2}-[0-9]{2}/', $actual, "should start with date");
 	}
 
 	public function testGetIncPath() {
-		$actual = ARC2::getIncPath('RDFParser');
+		$actual = \ARC2::getIncPath('RDFParser');
 		$this->assertStringEndsWith('parsers/', $actual, 'should create correct path');
 		$this->assertTrue(is_dir($actual), 'should create correct pointer');
 	}
-	
+
 	public function testGetScriptURI() {
 		$tmp = $_SERVER;
 		unset($_SERVER);
-		$actual = ARC2::getScriptURI();
+		$actual = \ARC2::getScriptURI();
 		$this->assertEquals('http://localhost/unknown_path', $actual);
 		$_SERVER = $tmp;
-		
+
 		$_SERVER = array(
 			'SERVER_PROTOCOL' => 'http',
 			'SERVER_PORT' => 443,
 			'HTTP_HOST' => 'example.com',
 			'SCRIPT_NAME' => '/foo'
 		);
-		$actual = ARC2::getScriptURI();
+		$actual = \ARC2::getScriptURI();
 		$this->assertEquals('https://example.com/foo', $actual);
 		$_SERVER = $tmp;
-		
+
 		unset($_SERVER['HTTP_HOST']);
 		unset($_SERVER['SERVER_NAME']);
 		$_SERVER['SCRIPT_FILENAME'] = __FILE__;
-		$actual = ARC2::getScriptURI();
+		$actual = \ARC2::getScriptURI();
 		$this->assertEquals('file://' . __FILE__, $actual);
 		$_SERVER = $tmp;
 	}
-	
+
 	public function testGetRequestURI() {
 		$tmp = $_SERVER;
 		unset($_SERVER);
-		$actual = ARC2::getRequestURI();
-		$this->assertEquals(ARC2::getScriptURI(), $actual);
+		$actual = \ARC2::getRequestURI();
+		$this->assertEquals(\ARC2::getScriptURI(), $actual);
 		$_SERVER = $tmp;
-		
+
 		$_SERVER = array(
 			'SERVER_PROTOCOL' => 'http',
 			'SERVER_PORT' => 1234,
 			'HTTP_HOST' => 'example.com',
 			'REQUEST_URI' => '/foo'
 		);
-		$actual = ARC2::getRequestURI();
+		$actual = \ARC2::getRequestURI();
 		$this->assertEquals('http://example.com:1234/foo', $actual);
 		$_SERVER = $tmp;
 	}
-	
+
 	public function testInc() {
-		$actual = ARC2::inc('Class');
+		$actual = \ARC2::inc('Class');
 		$this->assertNotEquals(0, $actual);
-		
-		$actual = ARC2::inc('RDFParser');
+
+		$actual = \ARC2::inc('RDFParser');
 		$this->assertNotEquals(0, $actual);
-		
-		$actual = ARC2::inc('ARC2_RDFParser');
+
+		$actual = \ARC2::inc('ARC2_RDFParser');
 		$this->assertNotEquals(0, $actual);
-		
-		$actual = ARC2::inc('Foo');
+
+		$actual = \ARC2::inc('Foo');
 		$this->assertEquals(0, $actual);
-		
-		$actual = ARC2::inc('Vendor_Foo');
+
+		$actual = \ARC2::inc('Vendor_Foo');
 		$this->assertEquals(0, $actual);
 	}
-	
+
 	public function testMtime() {
-		$actual = ARC2::mtime();
+		$actual = \ARC2::mtime();
 		$this->assertTrue(is_float($actual));
 	}
-	
+
 	public function testX() {
-		$actual = ARC2::x('foo', '  foobar');
+		$actual = \ARC2::x('foo', '  foobar');
 		$this->assertEquals('bar', $actual[1]);
 	}
-	
+
 	public function testToUTF8() {
-		$actual = ARC2::toUTF8('foo');
+		$actual = \ARC2::toUTF8('foo');
 		$this->assertEquals('foo', $actual);
-		
-		$actual = ARC2::toUTF8(utf8_encode('Iñtërnâtiônàlizætiøn'));
+
+		$actual = \ARC2::toUTF8(utf8_encode('Iñtërnâtiônàlizætiøn'));
 		$this->assertEquals('Iñtërnâtiônàlizætiøn', $actual);
 	}
-	
+
 	public function testSplitURI() {
-		$actual = ARC2::splitURI('http://www.w3.org/XML/1998/namespacefoo');
+		$actual = \ARC2::splitURI('http://www.w3.org/XML/1998/namespacefoo');
 		$this->assertEquals(array('http://www.w3.org/XML/1998/namespace', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://www.w3.org/2005/Atomfoo');
+
+		$actual = \ARC2::splitURI('http://www.w3.org/2005/Atomfoo');
 		$this->assertEquals(array('http://www.w3.org/2005/Atom', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://www.w3.org/2005/Atom#foo');
+
+		$actual = \ARC2::splitURI('http://www.w3.org/2005/Atom#foo');
 		$this->assertEquals(array('http://www.w3.org/2005/Atom#', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://www.w3.org/1999/xhtmlfoo');
+
+		$actual = \ARC2::splitURI('http://www.w3.org/1999/xhtmlfoo');
 		$this->assertEquals(array('http://www.w3.org/1999/xhtml', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://www.w3.org/1999/02/22-rdf-syntax-ns#foo');
+
+		$actual = \ARC2::splitURI('http://www.w3.org/1999/02/22-rdf-syntax-ns#foo');
 		$this->assertEquals(array('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://example.com/foo');
+
+		$actual = \ARC2::splitURI('http://example.com/foo');
 		$this->assertEquals(array('http://example.com/', 'foo'), $actual);
-		
-		$actual = ARC2::splitURI('http://example.com/foo/bar');
+
+		$actual = \ARC2::splitURI('http://example.com/foo/bar');
 		$this->assertEquals(array('http://example.com/foo/', 'bar'), $actual);
-		
-		$actual = ARC2::splitURI('http://example.com/foo#bar');
+
+		$actual = \ARC2::splitURI('http://example.com/foo#bar');
 		$this->assertEquals(array('http://example.com/foo#', 'bar'), $actual);
-		
+
 	}
-	
-	
+
+
 }

--- a/tests/unit/ARC2_getFormatTest.php
+++ b/tests/unit/ARC2_getFormatTest.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace Tests\unit;
+
+use Tests\ARC2_TestCase;
+
 define('TESTS_FOLDER_PATH', __DIR__ .'/../');
 
 class ARC2_getFormatTest extends ARC2_TestCase {
@@ -7,45 +11,45 @@ class ARC2_getFormatTest extends ARC2_TestCase {
 	public function testGetFormatWithAtom() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/atom/feed.atom');
 
-		$actual = ARC2::getFormat($data, 'application/atom+xml');
+		$actual = \ARC2::getFormat($data, 'application/atom+xml');
 		$this->assertEquals('atom', $actual);
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('atom', $actual);
 	}
 
 	public function testGetFormatWithRdfXml() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/rdfxml/planetrdf-bloggers.rdf');
 
-		$actual = ARC2::getFormat($data, 'application/rdf+xml');
+		$actual = \ARC2::getFormat($data, 'application/rdf+xml');
 		$this->assertEquals('rdfxml', $actual);
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('rdfxml', $actual);
 	}
 
 	public function testGetFormatWithTurtle() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/turtle/manifest.ttl');
 
-		$actual = ARC2::getFormat($data, 'text/turtle');
+		$actual = \ARC2::getFormat($data, 'text/turtle');
 		$this->assertEquals('turtle', $actual);
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('turtle', $actual);
 	}
 
 	public function testGetFormatWithJson() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/json/sparql-select-result.json');
 
-		$actual = ARC2::getFormat($data, 'application/json');
+		$actual = \ARC2::getFormat($data, 'application/json');
 		$this->assertEquals('json', $actual);
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('json', $actual);
 
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/json/crunchbase-facebook.js');
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('cbjson', $actual);
 
 	}
@@ -53,20 +57,20 @@ class ARC2_getFormatTest extends ARC2_TestCase {
 	public function testGetFormatWithN3() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/nt/test.nt');
 
-		$actual = ARC2::getFormat($data, 'application/rdf+n3');
+		$actual = \ARC2::getFormat($data, 'application/rdf+n3');
 		$this->assertEquals('n3', $actual);
 
-		$actual = ARC2::getFormat($data, '', 'n3');
+		$actual = \ARC2::getFormat($data, '', 'n3');
 		$this->assertEquals('n3', $actual);
 	}
 
 	public function testGetFormatWithNTriples() {
 		$data = file_get_contents(TESTS_FOLDER_PATH . 'data/nt/test.nt');
 
-		$actual = ARC2::getFormat($data);
+		$actual = \ARC2::getFormat($data);
 		$this->assertEquals('ntriples', $actual);
 
-		$actual = ARC2::getFormat($data, '', 'nt');
+		$actual = \ARC2::getFormat($data, '', 'nt');
 		$this->assertEquals('ntriples', $actual);
 	}
 

--- a/tests/unit/ARC2_getPreferredFormatTest.php
+++ b/tests/unit/ARC2_getPreferredFormatTest.php
@@ -1,21 +1,32 @@
 <?php
 
+namespace Tests\unit;
+
+use Tests\ARC2_TestCase;
+
 class ARC2_getPreferredFormatTest extends ARC2_TestCase {
+
+	public function setUp()
+	{
+        // fix warning about unset SCRIPT_NAME index in PHPUnit
+        // Notice: Undefined index: SCRIPT_NAME in /var/www/html/ARC2/vendor/phpunit/phpunit/src/Util/Filter.php on line 27
+        $_SERVER['SCRIPT_NAME'] = '';
+	}
 
 	public function testGetPreferredFormat() {
 		$_SERVER['HTTP_ACCEPT'] = '';
-		$actual = ARC2::getPreferredFormat('xml');
+		$actual = \ARC2::getPreferredFormat('xml');
 		$this->assertEquals('XML', $actual);
-		
-		$actual = ARC2::getPreferredFormat('foo');
+
+		$actual = \ARC2::getPreferredFormat('foo');
 		$this->assertEquals(null, $actual);
-		
+
 		$_SERVER['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
-		$actual = ARC2::getPreferredFormat();
+		$actual = \ARC2::getPreferredFormat();
 		$this->assertEquals('HTML', $actual);
-		
+
 		$_SERVER['HTTP_ACCEPT'] = 'application/rdf+xml,text/html;q=0.9,*/*;q=0.8';
-		$actual = ARC2::getPreferredFormat();
+		$actual = \ARC2::getPreferredFormat();
 		$this->assertEquals('RDFXML', $actual);
 	}
 


### PR DESCRIPTION
This rather complex pull request contains some work for the test area to enable connection tests for `ARC2_Store`. I also implemented namespacing for the test area (therefore adaptions on the composer.json).

**composer:**
- splitted classmap to classmap and files to allow autoload-dev
with psr-4. otherwise classes were loaded twice
- autoload-dev now cares about namespaces in the tests area

**tests in general:**
- extended bootstrap to load tests/config.php if available with
custom DB credentials
- added ARC2_StoreTest.php with very basic connection test.
this test hopefully covers the fix for #94 

**existing unit tests:**
- only adaptions to enable namespace usage for existing test classes
- ARC2_getPreferredFormatTest needed a simple workaround to avoid
"undefined index" warnings thrown by PHPUnit