### PR TITLE
Travis: added PHP 7.3 + 7.4 and MariaDB 10.4 and 10.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,14 @@ matrix:
           env: DB=mysql:5.6 DB_ADAPTER=mysqli
         - php: 7.2
           env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mysql:5.6 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mysql:5.6 DB_ADAPTER=mysqli
+        - php: 7.4
+          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         #
         # mysql 5.7
         #
@@ -78,6 +86,14 @@ matrix:
           env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         - php: 7.2
           env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.3
+          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.4
+          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
         #
         # mariadb 10
         #
@@ -96,6 +112,14 @@ matrix:
         - php: 7.2
           env: DB=mariadb:10.0 DB_ADAPTER=mysqli
         - php: 7.2
+          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
+        - php: 7.4
           env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         #
         # mariadb 10.1
@@ -116,6 +140,14 @@ matrix:
           env: DB=mariadb:10.1 DB_ADAPTER=mysqli
         - php: 7.2
           env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
+        - php: 7.4
+          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         #
         # mariadb 10.2
         #
@@ -134,6 +166,14 @@ matrix:
         - php: 7.2
           env: DB=mariadb:10.2 DB_ADAPTER=mysqli
         - php: 7.2
+          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
+        - php: 7.4
           env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         #
         # mariadb 10.3
@@ -162,7 +202,96 @@ matrix:
           env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         - php: 7.2
           env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-
+        - php: 7.3
+          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.4
+          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
+        - php: 7.4
+          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        #
+        # mariadb 10.4
+        #
+        - php: 5.6
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 5.6
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 5.6
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.0
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 7.0
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.0
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.1
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 7.1
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.1
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.2
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 7.2
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.2
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.3
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.4
+          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
+        - php: 7.4
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        #
+        # mariadb 10.5
+        #
+        - php: 5.6
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 5.6
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 5.6
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.0
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 7.0
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.0
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.1
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 7.1
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.1
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.2
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 7.2
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.2
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.3
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 7.3
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.3
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
+        - php: 7.4
+          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
+        - php: 7.4
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
+        - php: 7.4
+          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
 git:
     depth: 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,72 +14,8 @@ matrix:
         # For each DB version also tests with different adapters are run (mysqli, PDO).
         #
         #
-        # mysql 5.5
-        #
-        - php: 5.6
-          env: DB=mysql:5.5 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mysql:5.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mysql:5.5 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mysql:5.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mysql:5.5 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mysql:5.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mysql:5.5 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mysql:5.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        #
-        # mysql 5.6
-        #
-        - php: 5.6
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.3
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 7.3
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.4
-          env: DB=mysql:5.6 DB_ADAPTER=mysqli
-        - php: 7.4
-          env: DB=mysql:5.6 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        #
         # mysql 5.7
         #
-        - php: 5.6
-          env: DB=mysql:5.7 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 5.6
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.0
-          env: DB=mysql:5.7 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.1
-          env: DB=mysql:5.7 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
         - php: 7.2
           env: DB=mysql:5.7 DB_ADAPTER=mysqli
         - php: 7.2
@@ -94,52 +30,9 @@ matrix:
           env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         - php: 7.4
           env: DB=mysql:5.7 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        #
-        # mariadb 10
-        #
-        - php: 5.6
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.3
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 7.3
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.4
-          env: DB=mariadb:10.0 DB_ADAPTER=mysqli
-        - php: 7.4
-          env: DB=mariadb:10.0 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         #
         # mariadb 10.1
         #
-        - php: 5.6
-          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.1 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.1 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         - php: 7.3
           env: DB=mariadb:10.1 DB_ADAPTER=mysqli
         - php: 7.3
@@ -151,22 +44,6 @@ matrix:
         #
         # mariadb 10.2
         #
-        - php: 5.6
-          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.2 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.2 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
         - php: 7.3
           env: DB=mariadb:10.2 DB_ADAPTER=mysqli
         - php: 7.3
@@ -178,30 +55,6 @@ matrix:
         #
         # mariadb 10.3
         #
-        - php: 5.6
-          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 5.6
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.0
-          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.1
-          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.2
-          env: DB=mariadb:10.3 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.3 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
         - php: 7.3
           env: DB=mariadb:10.3 DB_ADAPTER=mysqli
         - php: 7.3
@@ -217,30 +70,6 @@ matrix:
         #
         # mariadb 10.4
         #
-        - php: 5.6
-          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 5.6
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.0
-          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.1
-          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.2
-          env: DB=mariadb:10.4 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.4 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
         - php: 7.3
           env: DB=mariadb:10.4 DB_ADAPTER=mysqli
         - php: 7.3
@@ -256,30 +85,6 @@ matrix:
         #
         # mariadb 10.5
         #
-        - php: 5.6
-          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
-        - php: 5.6
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 5.6
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.0
-          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
-        - php: 7.0
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.0
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.1
-          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
-        - php: 7.1
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.1
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
-        - php: 7.2
-          env: DB=mariadb:10.5 DB_ADAPTER=mysqli
-        - php: 7.2
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql
-        - php: 7.2
-          env: DB=mariadb:10.5 DB_ADAPTER=pdo DB_PDO_PROTOCOL=mysql CACHE_ENABLED=true
         - php: 7.3
           env: DB=mariadb:10.5 DB_ADAPTER=mysqli
         - php: 7.3


### PR DESCRIPTION
* Added tests for PHP 7.3 + 7.4 as well as MariaDB 10.4 and 10.5
* removed entries for unsupported PHP, MySQL and MariaDB versions

**Ref:**
* PHP: https://www.php.net/supported-versions.php
* MySQL: https://www.mysql.com/de/support/eol-notice.html
* MariaDB: https://downloads.mariadb.org/mariadb/+releases/