### PR TITLE
refector: Drop usage of xml_set_object()

### DIFF
--- a/parsers/ARC2_AtomParser.php
+++ b/parsers/ARC2_AtomParser.php
@@ -251,10 +251,9 @@ class ARC2_AtomParser extends ARC2_LegacyXMLParser
             $parser = xml_parser_create($enc);
             xml_parser_set_option($parser, \XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, \XML_OPTION_CASE_FOLDING, 0);
-            xml_set_element_handler($parser, 'open', 'close');
-            xml_set_character_data_handler($parser, 'cData');
-            xml_set_start_namespace_decl_handler($parser, 'nsDecl');
-            xml_set_object($parser, $this);
+            xml_set_element_handler($parser, [$this, 'open'], [$this, 'close']);
+            xml_set_character_data_handler($parser, [$this, 'cData']);
+            xml_set_start_namespace_decl_handler($parser, [$this, 'nsDecl']);
             $this->xml_parser = $parser;
         }
     }

--- a/parsers/ARC2_LegacyXMLParser.php
+++ b/parsers/ARC2_LegacyXMLParser.php
@@ -205,10 +205,9 @@ class ARC2_LegacyXMLParser extends ARC2_Class
             $parser = xml_parser_create_ns($enc, '');
             xml_parser_set_option($parser, \XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, \XML_OPTION_CASE_FOLDING, 0);
-            xml_set_element_handler($parser, 'open', 'close');
-            xml_set_character_data_handler($parser, 'cData');
-            xml_set_start_namespace_decl_handler($parser, 'nsDecl');
-            xml_set_object($parser, $this);
+            xml_set_element_handler($parser, [$this, 'open'], [$this, 'close']);
+            xml_set_character_data_handler($parser, [$this, 'cData']);
+            xml_set_start_namespace_decl_handler($parser, [$this, 'nsDecl']);
             $this->xml_parser = $parser;
         }
     }

--- a/parsers/ARC2_RDFXMLParser.php
+++ b/parsers/ARC2_RDFXMLParser.php
@@ -112,10 +112,9 @@ class ARC2_RDFXMLParser extends ARC2_RDFParser
             $parser = xml_parser_create_ns($enc, '');
             xml_parser_set_option($parser, \XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, \XML_OPTION_CASE_FOLDING, 0);
-            xml_set_element_handler($parser, 'open', 'close');
-            xml_set_character_data_handler($parser, 'cdata');
-            xml_set_start_namespace_decl_handler($parser, 'nsDecl');
-            xml_set_object($parser, $this);
+            xml_set_element_handler($parser, [$this, 'open'], [$this, 'close']);
+            xml_set_character_data_handler($parser, [$this, 'cData']);
+            xml_set_start_namespace_decl_handler($parser, [$this, 'nsDecl']);
             $this->xml_parser = $parser;
         }
     }

--- a/parsers/ARC2_SPOGParser.php
+++ b/parsers/ARC2_SPOGParser.php
@@ -100,10 +100,9 @@ class ARC2_SPOGParser extends ARC2_RDFParser
             $parser = xml_parser_create($enc);
             xml_parser_set_option($parser, \XML_OPTION_SKIP_WHITE, 0);
             xml_parser_set_option($parser, \XML_OPTION_CASE_FOLDING, 0);
-            xml_set_element_handler($parser, 'open', 'close');
-            xml_set_character_data_handler($parser, 'cdata');
-            xml_set_start_namespace_decl_handler($parser, 'nsDecl');
-            xml_set_object($parser, $this);
+            xml_set_element_handler($parser, [$this, 'open'], [$this, 'close']);
+            xml_set_character_data_handler($parser, [$this, 'cdata']);
+            xml_set_start_namespace_decl_handler($parser, [$this, 'nsDecl']);
             $this->xml_parser = $parser;
         }
     }


### PR DESCRIPTION
Use proper callables instead.

Related to: https://github.com/php/php-src/pull/12340