### PR TITLE
Fix : PDO::exec returns a false equivalent

### DIFF
--- a/store/ARC2_StoreSelectQueryHandler.php
+++ b/store/ARC2_StoreSelectQueryHandler.php
@@ -180,7 +180,7 @@ class ARC2_StoreSelectQueryHandler extends ARC2_StoreQueryHandler
         ) {
             return $this->addError($this->store->a['db_object']->getErrorMessage());
         }
-        if (false == $this->store->a['db_object']->exec('INSERT INTO '.$tbl.' '."\n".$q_sql)) {
+        if (false === $this->store->a['db_object']->exec('INSERT INTO '.$tbl.' '."\n".$q_sql)) {
             $this->addError($this->store->a['db_object']->getErrorMessage());
         }
 


### PR DESCRIPTION
Hello,

Correction of an incorrect comparison in ARC2_StoreSelectQueryHandler.php:
https://github.com/semsol/arc2/blob/3e08bc2af723496967bcdedff663e8094f6e5e66/store/ARC2_StoreSelectQueryHandler.php#L183

The PDO::exec function returns false on error, so `===` should be used instead of `==`.

---

Solve issue: https://github.com/semsol/arc2/issues/156#issue-2448671739